### PR TITLE
Executors.submit(Runnable) not returning a Future

### DIFF
--- a/sources/net.sf.j2s.java.core/src/java/util/concurrent/Executors.java
+++ b/sources/net.sf.j2s.java.core/src/java/util/concurrent/Executors.java
@@ -635,12 +635,6 @@ public class Executors {
             return e.awaitTermination(timeout, unit);
         }
         public Future<?> submit(Runnable task) {
-        	/**
-        	 * @j2sNative
-        	 * 
-        	 * task.run();
-        	 * return true;
-        	 */
             return e.submit(task);
         }
         public <T> Future<T> submit(Callable<T> task) {

--- a/sources/net.sf.j2s.java.core/src/java/util/concurrent/ScheduledThreadPoolExecutor.java
+++ b/sources/net.sf.j2s.java.core/src/java/util/concurrent/ScheduledThreadPoolExecutor.java
@@ -283,30 +283,38 @@ public class ScheduledThreadPoolExecutor
                                    executeExistingDelayedTasksAfterShutdown);
     }
 
-    /**
-     * Main execution method for delayed or periodic tasks.  If pool
-     * is shut down, rejects the task. Otherwise adds task to queue
-     * and starts a thread, if necessary, to run it.  (We cannot
-     * prestart the thread to run the task because the task (probably)
-     * shouldn't be run yet,) If the pool is shut down while the task
-     * is being added, cancel and remove it if required by state and
-     * run-after-shutdown parameters.
-     *
-     * @param task the task
-     */
-    private void delayedExecute(RunnableScheduledFuture<?> task) {
-        if (isShutdown())
-            reject(task);
-        else {
-            super.getQueue().add(task);
-            if (isShutdown() &&
-                !canRunInCurrentRunState(task.isPeriodic()) &&
-                remove(task))
-                task.cancel(false);
-            else
-                prestartCoreThread();
-        }
-    }
+	/**
+	 * Main execution method for delayed or periodic tasks. If pool is shut down,
+	 * rejects the task. Otherwise adds task to queue and starts a thread, if
+	 * necessary, to run it. (We cannot prestart the thread to run the task because
+	 * the task (probably) shouldn't be run yet,) If the pool is shut down while the
+	 * task is being added, cancel and remove it if required by state and
+	 * run-after-shutdown parameters.
+	 *
+	 * @param task the task
+	 */
+	@SuppressWarnings("unused")
+	private void delayedExecute(RunnableScheduledFuture<?> task) {
+		if (isShutdown())
+			reject(task);
+		else {
+			if (task.isPeriodic()) {
+				swingjs.JSUtil.notImplemented("Periodic tasks");
+			}
+
+			if (/** @j2sNative true || */
+			false) {
+				new Thread(task).start();
+			} else /** @j2sIgnore */
+			{
+				super.getQueue().add(task);
+				if (isShutdown() && !canRunInCurrentRunState(task.isPeriodic()) && remove(task))
+					task.cancel(false);
+				else
+					prestartCoreThread();
+			}
+		}
+	}
 
     /**
      * Requeues a periodic task unless current run state precludes it.

--- a/sources/net.sf.j2s.java.core/src/test/Test_Future.java
+++ b/sources/net.sf.j2s.java.core/src/test/Test_Future.java
@@ -22,6 +22,9 @@ import java.awt.event.ActionEvent;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 import javax.swing.JButton;
@@ -51,7 +54,21 @@ public class Test_Future extends JFrame {
 		future.thenAccept((value) -> {
 			System.out.format("returned with %s%n", value);
 		});
+		 ExecutorService dialogExecutor = Executors.newSingleThreadExecutor();
+		 Future<?> f = dialogExecutor.submit(() -> {
+			System.out.println("dialog runnable 1");
+		});
+		 dialogExecutor.submit(() -> {
+			System.out.println("dialog runnable 2");
+		});
+		 dialogExecutor.submit(() -> {
+			System.out.println("dialog runnable 3");
+			System.out.println(future.toString());
+		});
 		System.out.println("CompletionStage started");
+		System.out.println(future.toString());
+		
+		
 	}
 
 	CompletableFuture<String> longJob() {


### PR DESCRIPTION
A quick fix is to remove the 

task.run();
return;


from Executors.submit$Runnable()

This works in test.Test_Future.java  (hansonr1 branch):

		 ExecutorService dialogExecutor = Executors.newSingleThreadExecutor();
		 Future<?> f = dialogExecutor.submit(() -> {
			System.out.println("dialog runnable 1");
		});
		 dialogExecutor.submit(() -> {
			System.out.println("dialog runnable 2");
		});
		 dialogExecutor.submit(() -> {
			System.out.println("dialog runnable 3");
			System.out.println(f.toString() + f.isDone());
		});
		System.out.println("CompletionStage started");
		System.out.println(f.toString() + f.isDone());

delivering:

CompletionStage started
[java.util.concurrent.FutureTask object]false
dialog runnable 1
dialog runnable 2
dialog runnable 3
[java.util.concurrent.FutureTask object]true
