### PR TITLE
Fix SimpleHttpClient#toBytes, make sure return value is always byte[].

### DIFF
--- a/sources/net.sf.j2s.java.core/src/javajs/http/SimpleHttpClient.java
+++ b/sources/net.sf.j2s.java.core/src/javajs/http/SimpleHttpClient.java
@@ -287,22 +287,27 @@ public class SimpleHttpClient implements HttpClient {
 		}
 
 		private byte[] toBytes(Object data) {
-			try {
-				if (data == null || data instanceof byte[]) {
-				} else if (data instanceof File) {
-					FileInputStream fis = new FileInputStream((File) data);
-					data = getBytes(fis);
-					fis.close();
-				} else if (data instanceof InputStream) {
-					InputStream is = (InputStream) data;
-					data = getBytes(is);
-					is.close();
-				} else {
-					data = data.toString().getBytes();
+			if (data == null || data instanceof byte[]) {
+				return (byte[]) data;
+			} else if (data instanceof File) {
+				try (FileInputStream fis = new FileInputStream((File) data)) {
+					return getBytes(fis);
 				}
-			} catch (IOException e) {
+				catch (IOException e) {
+					e.printStackTrace();
+					return null;
+				}
+			} else if (data instanceof InputStream) {
+				try (InputStream is = (InputStream) data) {
+					return getBytes(is);
+				}
+				catch (IOException e) {
+					e.printStackTrace();
+					return null;
+				}
+			} else {
+				return data.toString().getBytes();
 			}
-			return (byte[]) data;
 		}
 
 		@Override


### PR DESCRIPTION
There was a possibility to leave the if/else chain without setting `data` to `byte[]` type. This change avoids reassigning `data` variable and makes sure that the correct type or null is always returned.