### PR TITLE
Use regular __CLASS_NAME__ to getParamCode.

### DIFF
--- a/sources/net.sf.j2s.java.core/srcjs/swingjs2.js
+++ b/sources/net.sf.j2s.java.core/srcjs/swingjs2.js
@@ -15234,7 +15234,7 @@ var shiftArray = function(a, i0, k) {
 
 var getParamCode = Clazz._getParamCode = function(cl) {
   cl.$clazz$ && (cl = cl.$clazz$);
-  return cl.__PARAMCODE || (cl.__PARAMCODE = stripJavaLang(cl.__CLASS_NAME$__ || cl.__CLASS_NAME__).replace(/\./g, '_'));
+  return cl.__PARAMCODE || (cl.__PARAMCODE = stripJavaLang(cl.__CLASS_NAME__).replace(/\./g, '_'));
 }
 
 var newTypedA = function(baseClass, args, nBits, ndims, isClone) {


### PR DESCRIPTION
Method names use non-dollar variant of their parameter names in their name even if inner types are used e.g. myMethod$org_example_Outer_Inner. Clazz._getParamCode was using a $-separated type name resulting in invalid method names produced by java.reflect tools.

**THIS CHANGE IS UNTESTED**
Please review and test this change. I'm not sure what other places getParamCode was used at that this change might break.

Fix #232