### PR TITLE
Change con.err() to con.error()

### DIFF
--- a/sources/net.sf.j2s.java.core/srcjs/js/j2sClazz.js
+++ b/sources/net.sf.j2s.java.core/srcjs/js/j2sClazz.js
@@ -3139,7 +3139,7 @@ Con.consoleOutput = function (s, color) {
   }
    if (con == window.console) {
     if (color == "red")
-      con.err(s);
+      con.error(s);
     else
       con.log(s);
     return;

--- a/sources/net.sf.j2s.java.core/srcjs/swingjs2.js
+++ b/sources/net.sf.j2s.java.core/srcjs/swingjs2.js
@@ -17193,7 +17193,7 @@ Con.consoleOutput = function (s, color) {
   }
    if (con == window.console) {
     if (color == "red")
-      con.err(s);
+      con.error(s);
     else
       con.log(s);
     return;


### PR DESCRIPTION
Hi Bob,
When trying to set 
Info = {
  ...
  console: window.console,
  ...
}
I got an error after launching jalviewjs:
TypeError: con.err is not a function loading file swingjs/j2s/java/lang/Class.js
TypeError: con.err is not a function
  at Con.consoleOutput (file://.../site/swingjs/swingjs2.js:16966:11)
  at file://.../site/swingjs/swingjs2.js:17302:33
  at ...
.

It looks like it should be error(s): this PR changes it in two files.
There is a workaround of defining con.err(s) with
window.console.err = function() {
        this.error.apply(this,arguments);
}
but presumably better to fix at source.
Ben

P.S. The context of this is piping the sysoutdiv output to shell STDERR of chromium running in headless mode so that we can look for specific output of JalviewJS to detect launch, or other operations:

mkdir -p /tmp/chrome/TEMP
touch "/tmp/chrome/TEMP/First Run"
chrome \
  --headless=new \
  --timeout=15000 \
  --virtual-time-budget=15000 \
  --user-data-dir=/tmp/chrome \
  --profile-directory=TEMP \
  --allow-file-access-from-files \
  --enable-logging=stderr \
  ./site/launcher_with_window_console.html